### PR TITLE
Allow closing the spawned window with q when inside it

### DIFF
--- a/lua/pretty-ts-errors/init.lua
+++ b/lua/pretty-ts-errors/init.lua
@@ -138,6 +138,18 @@ function M.show_formatted_error()
 	local win = api.nvim_open_win(floating_buf, false, opts)
 	floating_win_visible = true
 
+	-- Add 'q' key mapping to close the window
+	api.nvim_buf_set_keymap(floating_buf, "n", "q", "", {
+		noremap = true,
+		silent = true,
+		callback = function()
+			if api.nvim_win_is_valid(win) then
+				api.nvim_win_close(win, true)
+				floating_win_visible = false
+			end
+		end,
+	})
+
 	-- Set up an autocmd to reset `floating_win_visible` when the floating window is closed
 	api.nvim_create_autocmd("WinClosed", {
 		pattern = tostring(win), -- Trigger when this specific window is closed


### PR DESCRIPTION
When the error is long, I usually go inside the spawned diagnostic with `<C-w>w` (`:h CTRL-W_w`) so I can scroll it, and on normal diagnostic buffers, when focus is inside them, I'm able to just press q to close it and have the focus back on the original document buffer. 

Since this plugin creates a new buffer instead of relying on the normal diagnostics, this doesn't work by default, so this PR adds support for this. 
Without this, you can still close with the usual `:q`, but this makes it quicker to do so, and makes it behave more closely like the normal diagnostic buffer.

Let me know what you think :smile: 