### PR TITLE
Improve Windows compatibility and add ts_ls support

### DIFF
--- a/lua/pretty-ts-errors/diagnostics.lua
+++ b/lua/pretty-ts-errors/diagnostics.lua
@@ -9,10 +9,15 @@ local floating_win_visible = false
 local floating_win_id = nil
 
 -- get errors under the cursor and show formatted error as floating window near the cursor
-function M.show_formatted_error()
+function M.show_formatted_error(opts)
+	opts = opts or {}
+	opts.focus_existing_window = opts.focus_existing_window or true
+
 	-- If a floating window is already open, focus it instead of creating a new one
-	if floating_win_visible and floating_win_id ~= nil then
-		vim.api.nvim_set_current_win(floating_win_id)
+	if floating_win_visible then
+		if opts.focus_existing_window and floating_win_id ~= nil then
+			vim.api.nvim_set_current_win(floating_win_id)
+		end
 		return
 	end
 
@@ -252,7 +257,7 @@ function M.enable_auto_open()
 			end
 
 			if has_ts_error then
-				M.show_formatted_error()
+				M.show_formatted_error({ focus_existing_window = false })
 			end
 		end,
 	})

--- a/lua/pretty-ts-errors/diagnostics.lua
+++ b/lua/pretty-ts-errors/diagnostics.lua
@@ -6,10 +6,13 @@ local format = require("pretty-ts-errors.format")
 local api = vim.api
 
 local floating_win_visible = false
+local floating_win_id = nil
+
 -- get errors under the cursor and show formatted error as floating window near the cursor
 function M.show_formatted_error()
-	-- If we already have a floating window open, don't create another one
-	if floating_win_visible then
+	-- If a floating window is already open, focus it instead of creating a new one
+	if floating_win_visible and floating_win_id ~= nil then
+		vim.api.nvim_set_current_win(floating_win_id)
 		return
 	end
 
@@ -53,6 +56,7 @@ function M.show_formatted_error()
 	local win = api.nvim_open_win(floating_buf, false, opts)
 	api.nvim_set_option_value("wrap", config.get().float_opts.wrap, { win = win })
 	floating_win_visible = true
+	floating_win_id = win
 
 	-- Add 'q' key mapping to close the window
 	api.nvim_buf_set_keymap(floating_buf, "n", "q", "", {
@@ -62,6 +66,7 @@ function M.show_formatted_error()
 			if api.nvim_win_is_valid(win) then
 				api.nvim_win_close(win, true)
 				floating_win_visible = false
+				floating_win_id = nil
 			end
 		end,
 	})
@@ -71,6 +76,7 @@ function M.show_formatted_error()
 		pattern = tostring(win), -- Trigger when this specific window is closed
 		callback = function()
 			floating_win_visible = false
+			floating_win_id = nil
 		end,
 	})
 
@@ -88,6 +94,7 @@ function M.show_formatted_error()
 				if api.nvim_win_is_valid(win) then
 					api.nvim_win_close(win, true)
 					floating_win_visible = false
+					floating_win_id = nil
 					api.nvim_del_augroup_by_id(group)
 				end
 			end,
@@ -104,6 +111,7 @@ function M.show_formatted_error()
 				-- Make sure window is still valid
 				if not api.nvim_win_is_valid(win) or not api.nvim_buf_is_valid(floating_buf) then
 					floating_win_visible = false
+					floating_win_id = nil
 					return
 				end
 

--- a/lua/pretty-ts-errors/format.lua
+++ b/lua/pretty-ts-errors/format.lua
@@ -21,7 +21,8 @@ function M.format_error_async(diagnostic, callback)
 
 	-- Convert to JSON string and escape for shell
 	local json_str = vim.fn.json_encode(lsp_data)
-	local cmd = config.get().executable
+	local raw_cmd = config.get().executable
+	local cmd = utils.normalize_cmd(raw_cmd)
 
 	-- Use jobstart to run command asynchronously
 	local job_id = vim.fn.jobstart(cmd, {

--- a/lua/pretty-ts-errors/utils.lua
+++ b/lua/pretty-ts-errors/utils.lua
@@ -27,7 +27,7 @@ function M.update_buffer(buf, contents)
 end
 
 function M.is_ts_source(source)
-	return source == "tsserver" or source == "ts"
+	return vim.tbl_contains({ "tsserver", "ts", "typescript" }, source)
 end
 
 function M.is_windows()

--- a/lua/pretty-ts-errors/utils.lua
+++ b/lua/pretty-ts-errors/utils.lua
@@ -30,4 +30,26 @@ function M.is_ts_source(source)
 	return source == "tsserver" or source == "ts"
 end
 
+function M.is_windows()
+	return vim.loop.os_uname().version:match("Windows") ~= nil
+end
+
+-- Normalize command for jobstart on Windows (.cmd support)
+-- Accepts string or array of strings
+function M.normalize_cmd(cmd)
+	if type(cmd) == "string" then
+		cmd = { cmd }
+	end
+
+	if M.is_windows() then
+		local exe = cmd[1]
+
+		if not exe:match("%.cmd$") and vim.fn.executable(exe .. ".cmd") == 1 then
+			cmd[1] = exe .. ".cmd"
+		end
+	end
+
+	return cmd
+end
+
 return M

--- a/lua/pretty-ts-errors/utils.lua
+++ b/lua/pretty-ts-errors/utils.lua
@@ -31,7 +31,7 @@ function M.is_ts_source(source)
 end
 
 function M.is_windows()
-	return vim.loop.os_uname().version:match("Windows") ~= nil
+	return vim.uv.os_uname().sysname:match("Windows") ~= nil
 end
 
 -- Normalize command for jobstart on Windows (.cmd support)


### PR DESCRIPTION
First of all, thank you for the plugin – it works great and is very helpful.
Second, I'm new to Lua and Neovim, so I used ChatGPT to help me — please feel free to be strict with feedback!

**Environment:**
OS: Windows 11 Home
Windows Terminal: `1.22.11141.0`
Neovim: `0.10.4`
npm: `10.9.0`

### fix: add compatibility with ts_ls
The plugin didn’t work for me at first because I’m using `ts_ls` (typescript), not `vtsls `or `typescript-tools.nvim`.
I kept getting the message: _No TypeScript errors under cursor_.
I added support for this LSP source.

### fix(windows): normalize cmd path
There were errors related to starting the formatter binary on Windows:
```
E5108: Error executing lua: Vim:E903: Process failed to start: no such file or directory: "C:/Program"
```
and
```
E5108: Error executing lua: Vim:E903: Process failed to start: no such file or directory: "C:\nvm4w\nodejs\pretty-ts-errors-markdown"
```

### feat: focus existing window on repeat call
When calling `format_error_async()` repeatedly, the plugin now focuses the existing floating window instead of creating a new one — similar to how `vim.diagnostic.open_float()` behaves.