### PR TITLE
fix(diagnostics): run autocmd on explicit ESM / CJS files

### DIFF
--- a/lua/pretty-ts-errors/diagnostics.lua
+++ b/lua/pretty-ts-errors/diagnostics.lua
@@ -243,7 +243,7 @@ end
 function M.enable_auto_open()
 	local group = api.nvim_create_augroup("PrettyTsErrorsAuto", { clear = true })
 	api.nvim_create_autocmd("CursorHold", {
-		pattern = { "*.ts", "*.tsx", "*.js", "*.jsx" },
+		pattern = { "*.ts", "*.tsx", "*.mts", "*.cts", "*.js", "*.jsx", "*.mjs", "*.cjs" },
 		group = group,
 		callback = function()
 			local line = api.nvim_win_get_cursor(0)[1] - 1


### PR DESCRIPTION
`.mts` and `.cts` file extensions are used to explicitly differentiate ESM & CJS files.

https://www.typescriptlang.org/docs/handbook/modules/reference.html#module-format-detection