### PR TITLE
feat: add lazy_window option to show_formatted_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Here's the default configuration:
     wrap = false,              -- Whether to wrap long lines
   },
   auto_open = true,            -- Automatically show errors on hover
+  lazy_window = false,         -- Open the floating window only after errors are formatted
 }
 ```
 

--- a/lua/pretty-ts-errors/config.lua
+++ b/lua/pretty-ts-errors/config.lua
@@ -9,6 +9,7 @@ M.config = {
 		wrap = false,
 	},
 	auto_open = true,
+	lazy_window = false,
 }
 
 -- Merge user options with defaults

--- a/lua/pretty-ts-errors/diagnostics.lua
+++ b/lua/pretty-ts-errors/diagnostics.lua
@@ -8,55 +8,7 @@ local api = vim.api
 local floating_win_visible = false
 local floating_win_id = nil
 
--- get errors under the cursor and show formatted error as floating window near the cursor
-function M.show_formatted_error(opts)
-	opts = opts or {}
-	opts.focus_existing_window = opts.focus_existing_window or true
-
-	-- If a floating window is already open, focus it instead of creating a new one
-	if floating_win_visible then
-		if opts.focus_existing_window and floating_win_id ~= nil then
-			vim.api.nvim_set_current_win(floating_win_id)
-		end
-		return
-	end
-
-	-- Get diagnostics under cursor
-	local current_line = api.nvim_win_get_cursor(0)[1] - 1
-	local ts_diagnostics = {}
-	for _, diagnostic in ipairs(vim.diagnostic.get(0, { lnum = current_line })) do
-		if utils.is_ts_source(diagnostic.source) then
-			table.insert(ts_diagnostics, diagnostic)
-		end
-	end
-
-	if #ts_diagnostics == 0 then
-		vim.notify("No TypeScript errors under cursor", vim.log.levels.INFO)
-		return
-	end
-
-	local main_buf = api.nvim_get_current_buf()
-	local floating_buf = api.nvim_create_buf(false, true)
-	api.nvim_set_option_value("filetype", "markdown", { buf = floating_buf })
-
-	-- Add loading content to buffer
-	api.nvim_buf_set_lines(floating_buf, 0, -1, false, {
-		"# Loading TypeScript Error",
-		"",
-		"Please wait while the error is being formatted...",
-	})
-
-	-- Configure initial floating window
-	local opts = {
-		relative = "cursor",
-		width = 50,
-		height = 5,
-		row = 1,
-		col = 0,
-		style = "minimal",
-		border = config.get().float_opts.border,
-	}
-
+local function init_window(main_buf, floating_buf, opts)
 	-- Open floating window immediately with loading message
 	local win = api.nvim_open_win(floating_buf, false, opts)
 	api.nvim_set_option_value("wrap", config.get().float_opts.wrap, { win = win })
@@ -106,6 +58,63 @@ function M.show_formatted_error(opts)
 		})
 	end
 
+	return win
+end
+
+-- get errors under the cursor and show formatted error as floating window near the cursor
+function M.show_formatted_error(opts)
+	opts = opts or {}
+	opts.focus_existing_window = opts.focus_existing_window or true
+
+	local win_opts = {
+		relative = "cursor",
+		width = 50,
+		height = 5,
+		row = 1,
+		col = 0,
+		style = "minimal",
+		border = config.get().float_opts.border,
+	}
+
+	-- If a floating window is already open, focus it instead of creating a new one
+	if floating_win_visible then
+		if opts.focus_existing_window and floating_win_id ~= nil then
+			vim.api.nvim_set_current_win(floating_win_id)
+		end
+		return
+	end
+
+	-- Get diagnostics under cursor
+	local current_line = api.nvim_win_get_cursor(0)[1] - 1
+	local ts_diagnostics = {}
+	for _, diagnostic in ipairs(vim.diagnostic.get(0, { lnum = current_line })) do
+		if utils.is_ts_source(diagnostic.source) then
+			table.insert(ts_diagnostics, diagnostic)
+		end
+	end
+
+	if #ts_diagnostics == 0 then
+		vim.notify("No TypeScript errors under cursor", vim.log.levels.INFO)
+		return
+	end
+
+	local main_buf = api.nvim_get_current_buf()
+	local floating_buf = api.nvim_create_buf(false, true)
+	api.nvim_set_option_value("filetype", "markdown", { buf = floating_buf })
+
+	local window = nil
+	if not opts.lazy_window then
+		-- Add loading content to buffer
+		api.nvim_buf_set_lines(floating_buf, 0, -1, false, {
+			"# Loading TypeScript Error",
+			"",
+			"Please wait while the error is being formatted...",
+		})
+
+		-- Configure initial floating window
+		window = init_window(main_buf, floating_buf, win_opts)
+	end
+
 	local contents = ""
 
 	for _, diagnostic in ipairs(ts_diagnostics) do
@@ -114,7 +123,7 @@ function M.show_formatted_error(opts)
 			-- This callback runs when the formatting is complete
 			vim.schedule(function()
 				-- Make sure window is still valid
-				if not api.nvim_win_is_valid(win) or not api.nvim_buf_is_valid(floating_buf) then
+				if window ~= nil and not api.nvim_win_is_valid(window) or not api.nvim_buf_is_valid(floating_buf) then
 					floating_win_visible = false
 					floating_win_id = nil
 					return
@@ -138,8 +147,14 @@ function M.show_formatted_error(opts)
 				width = math.min(width, config.get().float_opts.max_width)
 				local height = math.min(#lines, config.get().float_opts.max_height)
 
+				if window == nil then
+					-- If the window is nil, that means we're in lazy window creation mode,
+					-- so initialise it here.
+					window = init_window(main_buf, floating_buf, win_opts)
+				end
+
 				-- Resize the window with new content
-				api.nvim_win_set_config(win, {
+				api.nvim_win_set_config(window, {
 					relative = "cursor",
 					width = width,
 					height = height,
@@ -159,7 +174,7 @@ function M.show_formatted_error(opts)
 		end
 	end
 
-	return win, floating_buf
+	return window, floating_buf
 end
 
 local error_buf = nil -- Store the buffer reference

--- a/lua/pretty-ts-errors/diagnostics.lua
+++ b/lua/pretty-ts-errors/diagnostics.lua
@@ -8,9 +8,18 @@ local api = vim.api
 local floating_win_visible = false
 local floating_win_id = nil
 
-local function init_window(main_buf, floating_buf, opts)
-	-- Open floating window immediately with loading message
-	local win = api.nvim_open_win(floating_buf, false, opts)
+local function init_window(main_buf, floating_buf)
+	local win_opts = {
+		relative = "cursor",
+		width = 50,
+		height = 5,
+		row = 1,
+		col = 0,
+		style = "minimal",
+		border = config.get().float_opts.border,
+	}
+
+	local win = api.nvim_open_win(floating_buf, false, win_opts)
 	api.nvim_set_option_value("wrap", config.get().float_opts.wrap, { win = win })
 	floating_win_visible = true
 	floating_win_id = win
@@ -67,16 +76,6 @@ function M.show_formatted_error(opts)
 	opts.focus_existing_window = opts.focus_existing_window or true
 	opts.lazy_window = opts.lazy_window or config.get().lazy_window
 
-	local win_opts = {
-		relative = "cursor",
-		width = 50,
-		height = 5,
-		row = 1,
-		col = 0,
-		style = "minimal",
-		border = config.get().float_opts.border,
-	}
-
 	-- If a floating window is already open, focus it instead of creating a new one
 	if floating_win_visible then
 		if opts.focus_existing_window and floating_win_id ~= nil then
@@ -113,7 +112,7 @@ function M.show_formatted_error(opts)
 		})
 
 		-- Configure initial floating window
-		window = init_window(main_buf, floating_buf, win_opts)
+		window = init_window(main_buf, floating_buf)
 	end
 
 	local contents = ""
@@ -159,7 +158,7 @@ function M.show_formatted_error(opts)
 				if window == nil then
 					-- If the window is nil, that means we're in lazy window creation mode,
 					-- so initialise it here.
-					window = init_window(main_buf, floating_buf, win_opts)
+					window = init_window(main_buf, floating_buf)
 				end
 
 				-- Resize the window with new content

--- a/lua/pretty-ts-errors/diagnostics.lua
+++ b/lua/pretty-ts-errors/diagnostics.lua
@@ -116,6 +116,7 @@ function M.show_formatted_error(opts)
 	end
 
 	local contents = ""
+	local resolved_count = 0
 
 	for _, diagnostic in ipairs(ts_diagnostics) do
 		-- Format the diagnostic asynchronously
@@ -137,6 +138,13 @@ function M.show_formatted_error(opts)
 
 				-- Update the buffer after each error is processed
 				utils.update_buffer(floating_buf, contents)
+				resolved_count = resolved_count + 1
+
+				if resolved_count < #ts_diagnostics and window == nil then
+					-- We're in lazy mode and not all diagnostics have been rendered
+					-- yet, so avoid creating the window until we know we have all of them
+					return
+				end
 
 				-- Recalculate window size for formatted content
 				local lines = vim.split(contents, "\n")

--- a/lua/pretty-ts-errors/diagnostics.lua
+++ b/lua/pretty-ts-errors/diagnostics.lua
@@ -65,6 +65,7 @@ end
 function M.show_formatted_error(opts)
 	opts = opts or {}
 	opts.focus_existing_window = opts.focus_existing_window or true
+	opts.lazy_window = opts.lazy_window or config.get().lazy_window
 
 	local win_opts = {
 		relative = "cursor",

--- a/lua/pretty-ts-errors/init.lua
+++ b/lua/pretty-ts-errors/init.lua
@@ -5,8 +5,8 @@ local config = require("pretty-ts-errors.config")
 local diagnostics = require("pretty-ts-errors.diagnostics")
 
 -- prevent breaking changes
-function M.show_formatted_error()
-	diagnostics.show_formatted_error()
+function M.show_formatted_error(opts)
+	diagnostics.show_formatted_error(opts)
 end
 function M.open_all_errors()
 	diagnostics.open_all_errors()


### PR DESCRIPTION
This means the floating window won't be created until the diagnostic can actually be rendered, avoiding the loading flash.

This is an opt-in flag to avoid the breaking change here where `show_formatted_error()` would return the window, but now it doesn't as the window hasn't actually been created yet.

Note I didn't add docs for this option - not sure what format you'd like / expect.

## Before


https://github.com/user-attachments/assets/6cd38392-3647-433a-a88a-0c8d71bcb1f9



## After


https://github.com/user-attachments/assets/b8840b4e-c764-4db4-b283-5be26bad1025

